### PR TITLE
Release/v1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ There are 6 arguments to be aware of use.
  - `foldHeight` : Define the Minimized Height. `Mandatory`
  - `halfExpandHeight` : Define the Half Expanded Height If you want to use Half Expanded State. If not defined, half expanded state is not used. `Optional`
  - `expandHeight` : Define the Fully Expanded Height. The default is `Dp.Unspecified`, which sets it to the parent's maximum height. `Optional`
+ - `swipeGestureEnabled` : You can disable swipe gesture. `default = true`
  - `nestedScrollEnabled` : You can enable nested scrolling to allowing seamless swipe gesture with scrollable composable like Column or LazyColumn. `default = true`
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,14 @@
 buildscript {
     ext {
         androidx_core_version = '1.13.1'
-        compose_bom_version = '2024.04.00'
+        compose_bom_version = '2024.06.00'
         compose_compiler_version = '1.5.8'
         kotlin_plugin_version = '1.9.22'
     }
 }
 
 plugins {
-    id 'com.android.application' version '8.1.0' apply false
-    id 'com.android.library' version '8.1.0' apply false
+    id 'com.android.application' version '8.1.4' apply false
+    id 'com.android.library' version '8.1.4' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_plugin_version" apply false
 }

--- a/expandablebox/build.gradle
+++ b/expandablebox/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'io.groovin'
                 artifactId = 'groovinexpandablebox'
-                version = '1.2.3'
+                version = '1.2.4'
             }
         }
     }

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     debugImplementation "androidx.compose.ui:ui-tooling"
 
     //Lifecycle
-    def lifecycle_version = '2.8.1'
+    def lifecycle_version = '2.8.2'
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"


### PR DESCRIPTION
**Add swipeGestureEnabled parameter, CorrectedOffset** 
 - Add swipeGestureEnabled parameter : User can enable/disable swipe gesture
 - Add CorrectedOffset for bugfix
   There is an issue where the status update does not work if the offset has an error of less than 5 decimal places.
   To fix this, we added a correctedOffset variable that discards less than 4 decimal places.
